### PR TITLE
[35] Keyword arguments for `get_surah_data`

### DIFF
--- a/cumulength.py
+++ b/cumulength.py
@@ -27,7 +27,8 @@ db_config = load_json_file(db_config_path)
 validate_db_config(db_config)
 
 with mysql.connector.connect(**db_config) as db_conn:
-	surah_data = get_surah_data(db_conn, chron_order, quran_period)
+	surah_data = get_surah_data(db_conn,
+		chron_order=chron_order, period=quran_period)
 	surah_data_size = len(surah_data)
 
 cumul_length_sum = 0

--- a/dump_surah_data.py
+++ b/dump_surah_data.py
@@ -27,5 +27,6 @@ db_config = load_json_file(db_config_path)
 validate_db_config(db_config)
 
 with mysql.connector.connect(**db_config) as db_conn:
-	surah_data = get_surah_data(db_conn, chron_order, quran_period)
+	surah_data = get_surah_data(db_conn,
+		chron_order=chron_order, period=quran_period)
 	write_csv(surah_file, COLUMN_NAMES, surah_data)

--- a/plot_progression_in_reading.py
+++ b/plot_progression_in_reading.py
@@ -7,7 +7,6 @@ based on the last surah entirely read.
 import matplotlib.pyplot as plt
 import mysql.connector
 
-from src import QuranPeriod
 from src.arg_parser import\
 	make_parser_plots
 from src.database.db_config_validation import\
@@ -39,8 +38,9 @@ db_config = load_json_file(db_config_path)
 validate_db_config(db_config)
 
 with mysql.connector.connect(**db_config) as db_conn:
-	surah_per_len_data = get_surah_data(db_conn, chron_order, QuranPeriod.UNDEF,
-		COLUMN_ID, COLUMN_PERIOD, COLUMN_NB_VERSES)
+	surah_per_len_data = get_surah_data(db_conn,
+		COLUMN_ID, COLUMN_PERIOD, COLUMN_NB_VERSES,
+		chron_order=chron_order)
 
 surah_nums_mec, surah_nums_med, surah_lengths_mec, surah_lengths_med\
 	= make_axes_values(surah_per_len_data, True)

--- a/plot_surah_length.py
+++ b/plot_surah_length.py
@@ -6,7 +6,6 @@ This script produces a bar diagram showing the surahs' length.
 import matplotlib.pyplot as plt
 import mysql.connector
 
-from src import QuranPeriod
 from src.arg_parser import\
 	make_parser_plots
 from src.database.db_config_validation import\
@@ -38,8 +37,9 @@ db_config = load_json_file(db_config_path)
 validate_db_config(db_config)
 
 with mysql.connector.connect(**db_config) as db_conn:
-	surah_per_len_data = get_surah_data(db_conn, chron_order, QuranPeriod.UNDEF,
-		COLUMN_ID, COLUMN_PERIOD, COLUMN_NB_VERSES)
+	surah_per_len_data = get_surah_data(db_conn,
+		COLUMN_ID, COLUMN_PERIOD, COLUMN_NB_VERSES,
+		chron_order=chron_order)
 
 surah_nums_mec, surah_nums_med, surah_lengths_mec, surah_lengths_med\
 	= make_axes_values(surah_per_len_data, False)

--- a/src/database/db_reading.py
+++ b/src/database/db_reading.py
@@ -56,9 +56,10 @@ def db_exists(cursor, db_name: str) -> bool:
 
 
 def get_surah_data(
-		db_conn, chron_order: bool,
-		period: QuranPeriod | int,
-		*column_names: str)\
+		db_conn,
+		*column_names: str,
+		chron_order: bool = False,
+		period: QuranPeriod | int = QuranPeriod.UNDEF)\
 		-> list[tuple | Any]:
 	"""
 	This function extracts data about the surahs from the database.
@@ -76,10 +77,12 @@ def get_surah_data(
 
 	Args:
 		db_conn: the connection to a database.
-		chron_order: If True, the surahs will be sorted in chronological order.
-			If False, the surhas will be sorted in traditional order.
-		period: the Meccan or Medinan period or no period.
 		column_names: the columns to select.
+		chron_order: If True, the surahs will be sorted in chronological order.
+			If False, the surhas will be sorted in traditional order. Defaults
+			to False.
+		period: the Meccan or Medinan period or no period. Defaults to
+			QuranPeriod.UNDEF.
 
 	Returns:
 		list: the rows extracted from the database.


### PR DESCRIPTION
In the signature of function `get_surah_data`, `chron_order` and `period` are keyword arguments declared after variable length argument `column_names`.

Close #35